### PR TITLE
Make European union endpoint optional - MixpanelDestination.swift

### DIFF
--- a/Sources/SegmentMixpanel/MixpanelDestination.swift
+++ b/Sources/SegmentMixpanel/MixpanelDestination.swift
@@ -327,7 +327,7 @@ extension MixpanelDestination: VersionedPlugin {
 
 private struct MixpanelSettings: Codable {
     let token: String
-    let enableEuropeanUnionEndpoint: Bool
+    let enableEuropeanUnionEndpoint: Bool?
     let consolidatedPageCalls: Bool
     let trackAllPages: Bool
     let trackNamedPages: Bool


### PR DESCRIPTION
Making the enable European endpoint in the destination setting an optional one so customers who have had this destination enabled for a while are able to migrate from iOS to Swift without any issues. Currently, this causes the plugin to fail as the CDN file does not contain the enableEuropeanUnionEndpoint setting.
Reference customer ticket - https://segment.zendesk.com/agent/tickets/517739 