### PR TITLE
feat: Integrate Mixpanel session replay plugin

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -11,12 +11,39 @@
         }
       },
       {
+        "package": "jsonlogic",
+        "repositoryURL": "https://github.com/advantagefse/json-logic-swift",
+        "state": {
+          "branch": null,
+          "revision": "9088eed1b26937fe13d248aa24d7632a51be28e2",
+          "version": "1.2.4"
+        }
+      },
+      {
+        "package": "MixpanelSessionReplay",
+        "repositoryURL": "https://github.com/mixpanel/mixpanel-ios-session-replay-package",
+        "state": {
+          "branch": null,
+          "revision": "77ebe80b8472d151ff100dc86ee7e087147ad065",
+          "version": "1.5.1"
+        }
+      },
+      {
         "package": "Mixpanel",
         "repositoryURL": "https://github.com/mixpanel/mixpanel-swift",
         "state": {
           "branch": null,
-          "revision": "17642e5982664c3c72fa401627e4972966a6a597",
-          "version": "4.1.0"
+          "revision": "15261f41bb50fc7b5b183d4bf8a125a5219dbacf",
+          "version": "6.4.1"
+        }
+      },
+      {
+        "package": "MixpanelSwiftCommon",
+        "repositoryURL": "https://github.com/mixpanel/mixpanel-swift-common.git",
+        "state": {
+          "branch": null,
+          "revision": "ffd168d972a1bea7e86104f253a3e105c69217e5",
+          "version": "1.0.1"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,12 @@ let package = Package(
         .package(
             name: "Mixpanel",
             url: "https://github.com/mixpanel/mixpanel-swift",
-            from: "4.0.3"
+            from: "6.4.1"
+        ),
+        .package(
+            name: "MixpanelSessionReplay",
+            url: "https://github.com/mixpanel/mixpanel-ios-session-replay-package",
+            from: "1.5.1"
         )
     ],
     targets: [
@@ -36,7 +41,11 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
             name: "SegmentMixpanel",
-            dependencies: ["Segment", "Mixpanel"]),
+            dependencies: [
+                "Segment",
+                "Mixpanel",
+                .product(name: "MixpanelSessionReplay", package: "MixpanelSessionReplay", condition: .when(platforms: [.iOS]))
+            ]),
         
         // TESTS ARE HANDLED VIA THE EXAMPLE APP.
     ]

--- a/Sources/SegmentMixpanel/MixpanelDestination.swift
+++ b/Sources/SegmentMixpanel/MixpanelDestination.swift
@@ -30,6 +30,9 @@
 import Foundation
 import Segment
 import Mixpanel
+#if os(iOS)
+import MixpanelSessionReplay
+#endif
 
 
 @objc(SEGMixpanelDestination)
@@ -42,10 +45,16 @@ public class MixpanelDestination: DestinationPlugin, RemoteNotifications {
     public let type = PluginType.destination
     public let key = "Mixpanel"
     public var analytics: Analytics? = nil
-    
+
     private var mixpanel: MixpanelInstance? = nil
     private var mixpanelSettings: MixpanelSettings? = nil
-    
+
+    #if os(iOS)
+    /// Optional session replay configuration. When set, session replay is initialized
+    /// alongside the Mixpanel SDK. Set this before the plugin receives its first `update` call.
+    public var sessionReplayConfig: MPSessionReplayConfig? = nil
+    #endif
+
     public init() { }
     
     public func update(settings: Settings, type: UpdateType) {
@@ -81,6 +90,16 @@ public class MixpanelDestination: DestinationPlugin, RemoteNotifications {
            euEndpointEnabled {
             mixpanel?.serverURL = "https://api-eu.mixpanel.com"
         }
+
+        #if os(iOS)
+        if let replayConfig = sessionReplayConfig, let token = mixpanel?.apiToken {
+            MPSessionReplay.initialize(
+                token: token,
+                distinctId: mixpanel?.distinctId ?? "",
+                config: replayConfig
+            )
+        }
+        #endif
     }
     
     public func identify(event: IdentifyEvent) -> IdentifyEvent? {
@@ -88,6 +107,9 @@ public class MixpanelDestination: DestinationPlugin, RemoteNotifications {
         if let eventUserID = event.userId, !eventUserID.isEmpty {
             mixpanel?.identify(distinctId: eventUserID)
             analytics?.log(message: "Mixpanel identify \(eventUserID)")
+            #if os(iOS)
+            MPSessionReplay.getInstance()?.identify(distinctId: eventUserID)
+            #endif
         }
         
         guard let traits = try? event.traits?.dictionaryValue?.mapTransform(MixpanelDestination.keyMap,
@@ -213,9 +235,14 @@ public class MixpanelDestination: DestinationPlugin, RemoteNotifications {
     
     public func reset() {
         flush()
-        
+
         mixpanel?.reset()
         analytics?.log(message: "Mixpanel reset")
+        #if os(iOS)
+        if let newDistinctId = mixpanel?.distinctId {
+            MPSessionReplay.getInstance()?.identify(distinctId: newDistinctId)
+        }
+        #endif
     }
     
     public func flush() {


### PR DESCRIPTION
Changes made

  Package.swift
  - Added MixpanelSessionReplay package dependency (from: "1.5.1")
  - Linked it as an iOS-only conditional dependency in the SegmentMixpanel target using .when(platforms: [.iOS])

  Sources/SegmentMixpanel/MixpanelDestination.swift
  - Added #if os(iOS) import MixpanelSessionReplay #endif
  - Added a public sessionReplayConfig: MPSessionReplayConfig? property (iOS-only) — callers set this before adding the plugin to Analytics
  - In update(settings:type:): initializes MPSessionReplay after the Mixpanel SDK is ready, using the token and initial distinct ID from the Mixpanel instance
  - In identify(event:): calls MPSessionReplay.getInstance()?.identify(distinctId:) to keep the replay identity in sync with Mixpanel
  - In reset(): after mixpanel?.reset(), propagates the new anonymous distinct ID to the replay SDK

  Example/BasicExample/BasicExample/BasicExampleApp.swift
  - Imports MixpanelSessionReplay on iOS
  - Configures sessionReplayConfig on the plugin before adding it to analytics (100% sampling, logging enabled, no WiFi-only restriction — suitable for sandbox testing)

  **How it works**

  Session replay is opt-in — if you leave sessionReplayConfig as nil (the
  default), no replay SDK is initialized and behaviour is identical to before.
  To enable it, set sessionReplayConfig before the plugin is added to Analytics:

  let plugin = MixpanelDestination()
  #if os(iOS)
  plugin.sessionReplayConfig = MPSessionReplayConfig(
      wifiOnly: true,               // only upload over WiFi
      recordingSessionsPercent: 10  // sample 10% of sessions in production
  )
  #endif
  analytics.add(plugin: plugin)