### PR TITLE
ci: migrate GHA to macos-arm + SHA-pinned actions

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -2,28 +2,19 @@ name: Swift
 
 on:
   push:
-    branches: [ main ]
   pull_request:
     branches: [ main ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  cancel_previous:
-    permissions: write-all
-    runs-on: ubuntu-latest
-    steps:
-    - uses: styfle/cancel-workflow-action@0.9.1
-      with:
-        workflow_id: ${{ github.event.workflow.id }}
-        
   build_and_test_examples:
-    needs: cancel_previous
-    runs-on: macos-latest
+    runs-on: macos-arm
     steps:
-    - uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: latest-stable
-    - uses: actions/checkout@v2
-    - uses: actions/cache@v2
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+    - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: /Users/runner/Library/Developer/Xcode/DerivedData
         key: ${{ runner.os }}-spm-examples-${{ hashFiles('**/Package.resolved') }}
@@ -33,4 +24,3 @@ jobs:
       run: |
           cd Example/BasicExample
           xcodebuild -workspace "BasicExample.xcworkspace" -scheme "BasicExample" -sdk iphonesimulator
-          


### PR DESCRIPTION
## Summary
- Migrate GitHub Actions CI to Twilio managed runners
- Move all macOS jobs to `macos-arm` (Apple Silicon)
- Remove blocked third-party actions (setup-xcode, cancel-workflow-action, ssh-agent, codecov); use native `concurrency` for cancellation
- Pin GitHub-owned actions to full commit SHA
- Trigger builds on push to any branch
- Refresh stale simulator device names where present

🤖 Generated with [Claude Code](https://claude.com/claude-code)